### PR TITLE
Freesurfer license file as an environment variable

### DIFF
--- a/cbrain_task_descriptors/shape_group_run.json
+++ b/cbrain_task_descriptors/shape_group_run.json
@@ -1,0 +1,1 @@
+../shape_group_run.json

--- a/shape_group_run.json
+++ b/shape_group_run.json
@@ -5,7 +5,7 @@
     "tool-version": "unknown",
     "descriptor-url": "https://raw.githubusercontent.com/glatard/enigma_shape-docker/master/shape_group_run.json",
     "schema-version": "0.5",
-    "command-line": "chmod 700 [FREESURFER_SUBJECT_DIR]/mri && cp [FS_LICENSE] /usr/local/freesurfer && echo $(basename [FREESURFER_SUBJECT_DIR]) > ids.csv && shape_group_run.sh ids.csv $(dirname [FREESURFER_SUBJECT_DIR]) shape-results",
+    "command-line": "export FS_LICENSE=$(readlink -e [FS_LICENSE]) ; chmod 700 [FREESURFER_SUBJECT_DIR]/mri && echo $(basename [FREESURFER_SUBJECT_DIR]) > ids.csv && shape_group_run.sh ids.csv $(dirname [FREESURFER_SUBJECT_DIR]) shape-results",
     "container-image": {
         "image": "glatard/enigma_shape:latest",
         "type": "docker"


### PR DESCRIPTION
The file cannot be copied to /usr/local/... when the container is created as a singularity image.

So instead it's set as an environment variable.